### PR TITLE
Fixed issue with sass-loader in vue.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # node-style-loader-async
 
-This is a fork from: https://github.com/iheartradio/node-style-loader
+This is a fork from a fork: https://github.com/radosny/node-style-loader
+original non-async repo: https://github.com/tarikjn/node-style-loader
 
-The only difference between node-style-loader and node-style-loader-async is support for async function in collectContext.
+The only difference between node-style-loader and redosny node-style-loader-async is support for async function in collectContext.
+
+This repo fixed sass loader issue in vue projects. Before it was not returning styles.
 
 A Webpack loader for loading styles on the server side. It behaves almost identically to how `style-loader` operates on the client side, which allows you to use it without changing the way you load CSS in your application components.
 

--- a/loader.js
+++ b/loader.js
@@ -17,6 +17,7 @@ module.exports.pitch = function(remainingRequest) {
     "// load the styles",
     "var content = require(" + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ");",
     "if (typeof content === 'string') content = [[module.id, content, '']];",
+    "else if (typeof content === 'object' && content.default) content = [[module.id, content.default[0][1], '']];",
     "// collect the styles",
     "require(" + loaderUtils.stringifyRequest(this, path.join(__dirname, "collect.js")) + ").add(content, " + JSON.stringify(query) + ");",
     "if (content.locals) module.exports = content.locals;",


### PR DESCRIPTION
Before package worked only with pure css import, but sass import returned empty string.
```
<style lang="css">
  body { color: #000; }
</style> // returns '<style class="server-style-loader-element">body {color: #000;}</style>'

<style lang="scss">
  body { color: #000; }
</style> // returns '<style class="server-style-loader-element"></style>'
```

[webpack.server.config.js](https://github.com/tarikjn/node-style-loader/files/6711595/webpack.server.config.txt)